### PR TITLE
fix: allow clippy useless_format for rsx interpolations

### DIFF
--- a/crates/mascot-web/Cargo.toml
+++ b/crates/mascot-web/Cargo.toml
@@ -45,3 +45,7 @@ wasm-bindgen-cli-support = "=0.2.120"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }
+# Dioxus `rsx!` expands single-variable interpolations like `"{color}"` into
+# `format!("{color}")`, which clippy flags as a useless format. The expansion is
+# macro-generated, so allow the lint rather than rewrite idiomatic markup.
+useless_format = "allow"


### PR DESCRIPTION
Nightly clippy flags the format! that Dioxus rsx generates for single-variable interpolations like "{color}". Allow the lint for the crate since the expansion is macro-generated and the markup is idiomatic.