### PR TITLE
Stop serving the font-dependent social-card SVG

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,6 +50,13 @@ jobs:
       - name: Install Dioxus CLI
         run: cargo install dioxus-cli --locked --version 0.7.6
 
+      # dx copies static assets into its output dir but never prunes stale ones,
+      # and the cached `target` can carry files removed from the source (for
+      # example a social-card.svg that is no longer served). Wipe the bundle so
+      # the uploaded artifact only contains what this build produced.
+      - name: Clean previous web bundle
+        run: rm -rf target/dx/mascot-web/release/web
+
       - name: Build web app
         run: dx build --platform web --release --package mascot-web
 

--- a/crates/mascot-web/social-card.svg
+++ b/crates/mascot-web/social-card.svg
@@ -1,3 +1,10 @@
+<!--
+  Source for the Open Graph social card. Text positions assume the DejaVu Sans
+  metrics, so this file is the build input only and is NOT served (browsers that
+  lack DejaVu Sans would substitute a different font and shift the layout). The
+  served, font-baked raster is public/social-card.png, regenerated with:
+    rsvg-convert -w 1200 -h 630 social-card.svg -o public/social-card.png
+-->
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" font-family="DejaVu Sans, sans-serif">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">


### PR DESCRIPTION
The social card SVG lays out text using DejaVu Sans metrics, so browsers without that font substitute another and the layout shifts, which is the png-vs-svg divergence. Only the PNG is referenced by the Open Graph and Twitter tags, so this moves the SVG out of the served public dir (kept as a build source) and adds a Pages clean step so a stale cached copy is never uploaded.